### PR TITLE
Generalize img url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ include/
 lib/
 pip-selfcheck.json
 .Python
+tcl/
+Scripts/
 
 *.env
 *.sql

--- a/twilio_app.py
+++ b/twilio_app.py
@@ -70,7 +70,7 @@ def get_nicknames(nickname_env_var, local_filename):
         return response.json()
     else:
         logging.info("loading nicknames from json dump...")
-        with open(local_filename, 'r') as f:
+        with open(local_filename, 'r', encoding="utf8") as f:
             nicknames = json.loads(f.read())
             return nicknames
     return []

--- a/twilio_app.py
+++ b/twilio_app.py
@@ -151,10 +151,10 @@ def recongize():
                 resp.message(failure_message)
                 del target_image
                 return str(resp)
-            key_str = 'applications/faces/' + str(uuid.uuid4()) + '.png'
+            key_str = 'faces/' + str(uuid.uuid4()) + '.png'
             target_image.get_image_file().seek(0)
-            s3.Bucket('int.nyt.com').put_object(Key=key_str, Body=target_image.get_image_file(), ContentType='image/png')
-            url = "https://int.nyt.com/" + key_str
+            s3.Bucket('who-the-hill').put_object(Key=key_str, Body=target_image.get_image_file(), ContentType='image/png')
+            url = os.environ['AWS_S3_ENDPOINT'] + "/who-the-hill/" + key_str
             logging.info("Image uploaded to: " + url)
             logging.info("\n".join(face_messages))
             resp.message("\n".join(face_messages))

--- a/twilio_app.py
+++ b/twilio_app.py
@@ -153,8 +153,9 @@ def recongize():
                 return str(resp)
             key_str = 'faces/' + str(uuid.uuid4()) + '.png'
             target_image.get_image_file().seek(0)
-            s3.Bucket('who-the-hill').put_object(Key=key_str, Body=target_image.get_image_file(), ContentType='image/png')
-            url = os.environ['AWS_S3_ENDPOINT'] + "/who-the-hill/" + key_str
+            bucket_folder_name = 'who-the-hill'
+            s3.Bucket(bucket_folder_name).put_object(Key=key_str, Body=target_image.get_image_file(), ContentType='image/png')
+            url = os.environ['AWS_S3_ENDPOINT'] + "/" + bucket_folder_name + "/" + key_str
             logging.info("Image uploaded to: " + url)
             logging.info("\n".join(face_messages))
             resp.message("\n".join(face_messages))


### PR DESCRIPTION
A leftover NYT link caused issues with receiving image replies from Twilio.